### PR TITLE
refactore parseTokens

### DIFF
--- a/inc/Calculation.h
+++ b/inc/Calculation.h
@@ -33,8 +33,6 @@ double returnAnswer(const std::string&);
 std::deque<CalculationToken> parseTokensFromRequest(const std::string&);
 std::deque<CalculationToken> produceRPNQueue(std::deque<CalculationToken>);
 double evaluateRPN(std::deque<CalculationToken>);
-std::deque<CalculationToken> organizeNumbers(std::deque<CalculationToken>);
-std::deque<CalculationToken> organizeDecimals(std::deque<CalculationToken>);
 double performMathOperation(char, double, double);
 char returnOperatorPrecedence(char);
 bool isCharAnOperator(char);


### PR DESCRIPTION
Moved all the functionality of reading tokens to one function. This allowed to read tokens in one iteration over expression